### PR TITLE
Fixed encoding issues to make it run on Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ $ ./S20control.py globaldiscover 192.168.242.255
 ```
 
 Again, use the appropriate broadcast address for your network.
-Subscribe, Power On, Power Off
+
+## Subscribe, Power On, Power Off
 
 These are all more or less the same structure. The response from the Subscribe command on it's own tells you very little of use other than the state of the switch which you can also get from the Discover command.
 
@@ -138,7 +139,8 @@ There is a set of bytes used for some sort of time in many of the returned packe
 After examining these in more detail, I personally think that this set is a 4-byte (32-bit) unsigned integer which at the time of writing works out as just over 116 years worth of seconds which got me thinking - it looks like it could be the number of seconds since 1900 (rather than the usual Unix Epoch of 1970). In my experimenting this seems to hold true so that's how I'm interpreting it.
 
 One thing to note with this way of measurement is that the roll-over will occur in 2036 which is a lot closer than ideal - in fact at this point my S20 has almost exactly 10 years before weird stuff could happen with it.
-Zeroes
+
+## Zeroes
 
 The series of zero bytes after the MAC addresses in the response to a poweron/poweroff command is zero only when there is one S20 on the network. With a second one the first byte turns to a 0x01. Could this be a count of other devices on the network? I only have two so can't be sure.
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ $ ./S20control.py globaldiscover 192.168.242.255
 
 Again, use the appropriate broadcast address for your network.
 
-## Subscribe, Power On, Power Off
+### Subscribe, Power On, Power Off
 
 These are all more or less the same structure. The response from the Subscribe command on it's own tells you very little of use other than the state of the switch which you can also get from the Discover command.
 
@@ -140,7 +140,7 @@ After examining these in more detail, I personally think that this set is a 4-by
 
 One thing to note with this way of measurement is that the roll-over will occur in 2036 which is a lot closer than ideal - in fact at this point my S20 has almost exactly 10 years before weird stuff could happen with it.
 
-## Zeroes
+### Zeroes
 
 The series of zero bytes after the MAC addresses in the response to a poweron/poweroff command is zero only when there is one S20 on the network. With a second one the first byte turns to a 0x01. Could this be a count of other devices on the network? I only have two so can't be sure.
 

--- a/S20control/S20control.py
+++ b/S20control/S20control.py
@@ -35,6 +35,7 @@ import pprint
 import socket
 import struct
 import time
+import re
 
 
 # get args
@@ -329,34 +330,34 @@ def main():
         sock.settimeout(2)  # seconds - in reality << 1 is needed
 
         # connect to network
-        sock.sendto('HF-A11ASSISTHREAD', (ip, 48899))
+        sock.sendto('HF-A11ASSISTHREAD'.encode(), (ip, 48899))
         data, addr = sock.recvfrom(1024)
-        socketip, socketmac, sockethost = data.split(',')
+        socketip, socketmac, sockethost = data.decode().split(',')
         print(socketip, socketmac, sockethost)
-        sock.sendto('+ok', (ip, 48899))  # ack
-        sock.sendto("AT+WSSSID=%s\r" % wlan, (ip, 48899))
+        sock.sendto('+ok'.encode(), (ip, 48899))  # ack
+        sock.sendto(("AT+WSSSID=%s\r" % wlan).encode(), (ip, 48899))
         data, addr = sock.recvfrom(1024)
 
-        if data.rstrip() != '+ok':
-            print('FATAL - got "%s" in response to set SSID' % data.rstrip(), file=sys.stderr)
+        if data.decode().rstrip() != '+ok':
+            print('FATAL - got "%s" in response to set SSID' % data.decode().rstrip(), file=sys.stderr)
             sys.exit(1)
 
         key = input('Enter WIFI key for "%s": ' % wlan)
-        sock.sendto("AT+WSKEY=WPA2PSK,AES,%s\r" % key, (ip, 48899))
+        sock.sendto(("AT+WSKEY=WPA2PSK,AES,%s\r" % key).encode(), (ip, 48899))
         data, addr = sock.recvfrom(1024)
 
-        if data.rstrip() != '+ok':
-            print('FATAL - got "%s" in response to set KEY' % data.rstrip(), file=sys.stderr)
+        if data.decode().rstrip() != '+ok':
+            print('FATAL - got "%s" in response to set KEY' % data.decode().rstrip(), file=sys.stderr)
             sys.exit(1)
 
-        sock.sendto("AT+WMODE=STA\r", (ip, 48899))
+        sock.sendto("AT+WMODE=STA\r".encode(), (ip, 48899))
         data, addr = sock.recvfrom(1024)
 
-        if data.rstrip() != '+ok':
-            print('FATAL - got "%s" in response to set MODE' % data.rstrip(), file=sys.stderr)
+        if data.decode().rstrip() != '+ok':
+            print('FATAL - got "%s" in response to set MODE' % data.decode().rstrip(), file=sys.stderr)
             sys.exit(1)
 
-        sock.sendto("AT+Z\r", (ip, 48899))  # no return
+        sock.sendto("AT+Z\r".encode(), (ip, 48899))  # no return
         print("connect complete to \"%s\"" % wlan)
 
     elif command == 'listen':  # listen for stuff sent round


### PR DESCRIPTION
Fixed encoding issues to make it run on Python3.
Remaining issue, unrelated to my fix: if the wifi password has not alphanumerical characters ("=", ","...), the device will return an error. Not sure how to fix it, tried escaping them, but no dice.